### PR TITLE
Fix filtering only `participating` notifications.

### DIFF
--- a/src/main/typescript/client/GitHubClientImpl.ts
+++ b/src/main/typescript/client/GitHubClientImpl.ts
@@ -65,7 +65,7 @@ export class GitHubClientImpl implements GitHubClient {
     public async listThreads(showParticipatingOnly: boolean = false): Promise<GitHub.Thread[]> {
         const response = await this.doRequest(
             HttpMethod.GET,
-            `https://${this.baseUrl}/notifications?${showParticipatingOnly.toString()}`,
+            `https://${this.baseUrl}/notifications?participating=${showParticipatingOnly.toString()}`,
             [HttpStatus.Ok]
         );
 

--- a/src/test/resources/client/github-client-scenarios.json
+++ b/src/test/resources/client/github-client-scenarios.json
@@ -1,7 +1,7 @@
 {
     "fetch-all-threads": {
         "request": {
-            "url": "https://api.github.com/notifications?false",
+            "url": "https://api.github.com/notifications?participating=false",
             "method": "GET",
             "headers": {
                 "Authorization": "Bearer fake-token",
@@ -183,7 +183,7 @@
     },
     "fetch-threads-fails": {
         "request": {
-            "url": "https://api.github.com/notifications?false",
+            "url": "https://api.github.com/notifications?participating=false",
             "method": "GET",
             "headers": {
                 "Authorization": "Bearer fake-token",


### PR DESCRIPTION
The actual query parameter was missing, see the [docs](https://docs.github.com/en/rest/activity/notifications?apiVersion=2022-11-28#list-notifications-for-the-authenticated-user).

Thank you so much for continuing the work in this extension! :star_struck:  Although seemingly simple, seeing the current notification count at the top of my screen and clicking it to get redirected to the unread notifications is so essential to my workflow. Keep up the good work! It would be so awesome if you could get it published as well, since there is nothing comparable anymore in the registry for recent Gnome versions.